### PR TITLE
Zarr arrays/Lsf queue

### DIFF
--- a/cellpose/contrib/distributed_segmentation.py
+++ b/cellpose/contrib/distributed_segmentation.py
@@ -774,8 +774,8 @@ def distributed_eval(
                 ncpus=1,
                 memory="15GB",
                 mem=int(15e9),
-                queue=None,
-                job_extra_directives=[],
+                queue=cluster.locals_store['kwargs']['queue'],
+                job_extra_directives=cluster.locals_store['kwargs']['job_extra_directives'],
             )
     
         segmentation_da = dask.array.from_zarr(temp_zarr)

--- a/cellpose/contrib/distributed_segmentation.py
+++ b/cellpose/contrib/distributed_segmentation.py
@@ -733,7 +733,8 @@ def distributed_eval(
 
         temp_zarr_path = temporary_directory + '/segmentation_unstitched.zarr'
         temp_zarr = zarr.open(
-            temp_zarr_path, 'w',
+            store=temp_zarr_path,
+            mode = 'w',
             shape=input_zarr.shape,
             chunks=blocksize,
             dtype=np.uint32,

--- a/cellpose/contrib/distributed_segmentation.py
+++ b/cellpose/contrib/distributed_segmentation.py
@@ -887,6 +887,8 @@ def block_face_adjacency_graph(faces, nlabels):
         face = np.concatenate((a, b), axis=np.argmin(a.shape))
         mapped = dask_image.ndmeasure._utils._label._across_block_label_grouping(face, structure)
         all_mappings.append(mapped)
+    if not all_mappings:
+        return scipy.sparse.coo_matrix((nlabels+1, nlabels+1)).tocsr()
     i, j = np.concatenate(all_mappings, axis=1)
     v = np.ones_like(i)
     return scipy.sparse.coo_matrix((v, (i, j)), shape=(nlabels+1, nlabels+1)).tocsr()

--- a/cellpose/models.py
+++ b/cellpose/models.py
@@ -187,7 +187,7 @@ class CellposeModel():
             flow_threshold (float, optional): flow error threshold (all cells with errors below threshold are kept) (not used for 3D). Defaults to 0.4.
             cellprob_threshold (float, optional): all pixels with value above threshold kept for masks, decrease to find more and larger masks. Defaults to 0.0.
             do_3D (bool, optional): set to True to run 3D segmentation on 3D/4D image input. Defaults to False.
-            flow3D_smooth (int, optional): if do_3D and flow3D_smooth>0, smooth flows with gaussian filter of this stddev. Defaults to 0.
+            flow3D_smooth (int, list[int] optional): if do_3D and flow3D_smooth>0, smooth flows with gaussian filter of this stddev. Defaults to 0.
             anisotropy (float, optional): for 3D segmentation, optional rescaling factor (e.g. set to 2.0 if Z is sampled half as dense as X or Y). Defaults to None.
             stitch_threshold (float, optional): if stitch_threshold>0.0 and not do_3D, masks are stitched in 3D to return volume segmentation. Defaults to 0.0.
             min_size (int, optional): all ROIs below this size, in pixels, will be discarded. Defaults to 15.
@@ -319,10 +319,12 @@ class CellposeModel():
             do_3D=do_3D, 
             anisotropy=anisotropy)
 
-        if do_3D:    
-            if flow3D_smooth > 0:
+        if do_3D:
+            if isinstance(flow3D_smooth, int):
+                flow3D_smooth = [flow3D_smooth]*3 
+            if any(v > 0 for v in flow3D_smooth):
                 models_logger.info(f"smoothing flows with sigma={flow3D_smooth}")
-                dP = gaussian_filter(dP, (0, flow3D_smooth, flow3D_smooth, flow3D_smooth))
+                dP = gaussian_filter(dP, [0, *flow3D_smooth])
             torch.cuda.empty_cache()
             gc.collect()
 


### PR DESCRIPTION
- Should work now with zarr v2/v3 arrays
- Merge blocks on the same lsf queue
- Bug: If there's only one block, there are no boundaries, so all_mappings stays [] (empty) -> should pass empty sparse adjacency matrix.
